### PR TITLE
Add "select" lazy operation

### DIFF
--- a/lib/explorer_sql.ex
+++ b/lib/explorer_sql.ex
@@ -25,10 +25,28 @@ defmodule ExplorerSQL do
     end
   end
 
+  ## Introspection
+
+  def names(%DF{data: %SQLDF{} = sql_df}), do: sql_df.columns
+
   def to_sql(%DF{data: %SQLDF{} = sql_df}), do: PG.to_sql(sql_df)
+
+  ## Verbs
 
   def head(%DF{data: %SQLDF{}} = df, n_rows \\ 5) when is_integer(n_rows) do
     maybe_add_operation(df, {:head, [n_rows]})
+  end
+
+  def select(%DF{data: %SQLDF{}} = df, columns, keep_or_drop)
+      when is_list(columns) and keep_or_drop in [:keep, :drop] do
+    columns =
+      if keep_or_drop == :keep do
+        columns
+      else
+        names(df) -- columns
+      end
+
+    maybe_add_operation(df, {:select, [columns]})
   end
 
   defp maybe_add_operation(%DF{data: %SQLDF{} = sql_df} = df, operation) do

--- a/lib/explorer_sql.ex
+++ b/lib/explorer_sql.ex
@@ -3,10 +3,11 @@ defmodule ExplorerSQL do
   Documentation for `ExplorerSQL`.
   """
 
+  alias Explorer.DataFrame, as: DF
+
   alias ExplorerSQL.Adapters.Postgres, as: PG
   alias ExplorerSQL.Backend.DataFrame, as: SQLDF
-
-  alias Explorer.DataFrame, as: DF
+  alias ExplorerSQL.Query
 
   @doc """
   Starts a new ExplorerSQL process.
@@ -19,7 +20,13 @@ defmodule ExplorerSQL do
 
   def table(pid, name) do
     with {:ok, {columns, dtypes}} <- PG.table_description(pid, name) do
-      sql_df = %SQLDF{pid: pid, table: name, columns: columns, dtypes: dtypes}
+      sql_df = %SQLDF{
+        pid: pid,
+        table: name,
+        columns: columns,
+        dtypes: dtypes,
+        query: Query.new(name)
+      }
 
       %Explorer.DataFrame{data: sql_df, groups: []}
     end
@@ -34,7 +41,7 @@ defmodule ExplorerSQL do
   ## Verbs
 
   def head(%DF{data: %SQLDF{}} = df, n_rows \\ 5) when is_integer(n_rows) do
-    maybe_add_operation(df, {:head, [n_rows]})
+    update_query(df, &Query.put_limit(&1, n_rows))
   end
 
   def select(%DF{data: %SQLDF{}} = df, columns, keep_or_drop)
@@ -46,16 +53,12 @@ defmodule ExplorerSQL do
         names(df) -- columns
       end
 
-    maybe_add_operation(df, {:select, [columns]})
+    update_query(df, &Query.put_columns(&1, columns))
   end
 
-  defp maybe_add_operation(%DF{data: %SQLDF{} = sql_df} = df, operation) do
-    case {operation, List.first(sql_df.operations)} do
-      {operation, operation} ->
-        df
+  defp update_query(df, new_plan_fun) when is_function(new_plan_fun) do
+    new_plan = new_plan_fun.(df.data.query)
 
-      {operation, _last_is_other} ->
-        %{df | data: %{sql_df | operations: [operation | sql_df.operations]}}
-    end
+    %{df | data: %{df.data | query: new_plan}}
   end
 end

--- a/lib/explorer_sql/backend/data_frame.ex
+++ b/lib/explorer_sql/backend/data_frame.ex
@@ -1,4 +1,4 @@
 defmodule ExplorerSQL.Backend.DataFrame do
   @moduledoc false
-  defstruct table: nil, pid: nil, columns: [], dtypes: [], operations: []
+  defstruct table: nil, pid: nil, columns: [], dtypes: [], query: nil
 end

--- a/lib/explorer_sql/query.ex
+++ b/lib/explorer_sql/query.ex
@@ -1,4 +1,4 @@
-defmodule ExplorerSQL.QueryPlan do
+defmodule ExplorerSQL.Query do
   @moduledoc false
   # Holds all data to construct a SELECT query by the adapters.
 
@@ -7,7 +7,6 @@ defmodule ExplorerSQL.QueryPlan do
   # If some operation is "replaced" by other, then the first one is "pushed" to a subquery
   defstruct columns: nil,
             from: nil,
-            subquery: nil,
             condition: nil,
             group_by: nil,
             having: nil,
@@ -16,19 +15,23 @@ defmodule ExplorerSQL.QueryPlan do
             limit: nil,
             offset: nil
 
+  def new(table) when is_binary(table) do
+    %__MODULE__{from: table}
+  end
+
   def new(lazy_frame) do
     %__MODULE__{from: lazy_frame.table}
   end
 
-  def put_limit(%__MODULE__{} = plan, limit_string) do
-    %{plan | limit: limit_string}
+  def put_limit(%__MODULE__{} = plan, limit) when is_integer(limit) do
+    %{plan | limit: to_string(limit)}
   end
 
-  def put_columns(%__MODULE__{} = plan, columns_iodata) do
+  def put_columns(%__MODULE__{} = plan, columns) when is_list(columns) do
     if is_nil(plan.limit) do
-      %{plan | columns: columns_iodata}
+      %{plan | columns: columns}
     else
-      %__MODULE__{subquery: plan, columns: columns_iodata}
+      %__MODULE__{from: plan, columns: columns}
     end
   end
 end

--- a/lib/explorer_sql/query_plan.ex
+++ b/lib/explorer_sql/query_plan.ex
@@ -4,8 +4,10 @@ defmodule ExplorerSQL.QueryPlan do
 
   # Fields where based in the SELECT syntax of PostgreSQL:
   # https://www.postgresql.org/docs/current/sql-select.html
+  # If some operation is "replaced" by other, then the first one is "pushed" to a subquery
   defstruct columns: nil,
-            from_item: nil,
+            from: nil,
+            subquery: nil,
             condition: nil,
             group_by: nil,
             having: nil,
@@ -13,4 +15,20 @@ defmodule ExplorerSQL.QueryPlan do
             order_by: nil,
             limit: nil,
             offset: nil
+
+  def new(lazy_frame) do
+    %__MODULE__{from: lazy_frame.table}
+  end
+
+  def put_limit(%__MODULE__{} = plan, limit_string) do
+    %{plan | limit: limit_string}
+  end
+
+  def put_columns(%__MODULE__{} = plan, columns_iodata) do
+    if is_nil(plan.limit) do
+      %{plan | columns: columns_iodata}
+    else
+      %__MODULE__{subquery: plan, columns: columns_iodata}
+    end
+  end
 end

--- a/test/explorer_sql_test.exs
+++ b/test/explorer_sql_test.exs
@@ -48,7 +48,86 @@ defmodule ExplorerSQLTest do
 
       statement = ExplorerSQL.to_sql(ldf)
 
-      assert statement == "SELECT * FROM \"links\" LIMIT 5"
+      assert statement ==
+               String.trim("""
+               SELECT * FROM "links"
+               LIMIT 5
+               """)
+    end
+
+    test "with `select` operation returns SQL statement selecting two columns", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url", "clicks" FROM "links"
+               """)
+    end
+
+    test "combine a `select` operation with a `head` operation", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+      ldf = ExplorerSQL.head(ldf)
+
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url", "clicks" FROM "links"
+               LIMIT 5
+               """)
+    end
+
+    test "performs a subquery if `head` comes before `select`", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.head(ldf)
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url", "clicks" FROM (
+                 SELECT * FROM "links"
+                 LIMIT 5)
+               """)
+
+      ldf = ExplorerSQL.head(ldf, 3)
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url", "clicks" FROM (
+                 SELECT * FROM "links"
+                 LIMIT 5)
+               LIMIT 3
+               """)
+    end
+
+    test "keep the columns from the last `select` if possible", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+      ldf = ExplorerSQL.select(ldf, ["url"], :keep)
+
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url" FROM "links"
+               """)
+
+      ldf = ExplorerSQL.head(ldf, 12)
+
+      statement = ExplorerSQL.to_sql(ldf)
+
+      assert statement ==
+               String.trim("""
+               SELECT "url" FROM "links"
+               LIMIT 12
+               """)
     end
   end
 
@@ -84,6 +163,41 @@ defmodule ExplorerSQLTest do
       ldf = ExplorerSQL.head(ldf)
 
       assert ldf.data.operations == [{:head, [5]}]
+    end
+  end
+
+  describe "select/3" do
+    test "adds a select operation with only two columns", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+
+      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+
+      ldf = ExplorerSQL.select(ldf, ["url"], :keep)
+
+      assert ldf.data.operations == [{:select, [["url"]]}, {:select, [["url", "clicks"]]}]
+    end
+
+    test "adds a select operation removing one column", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["id"], :drop)
+
+      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+
+      ldf = ExplorerSQL.select(ldf, ["clicks"], :drop)
+
+      assert ldf.data.operations == [{:select, [["id", "url"]]}, {:select, [["url", "clicks"]]}]
+    end
+
+    test "does not add the same select operation twice in a row", %{pid: pid} do
+      ldf = ExplorerSQL.table(pid, "links")
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+
+      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+
+      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
+
+      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
     end
   end
 end

--- a/test/explorer_sql_test.exs
+++ b/test/explorer_sql_test.exs
@@ -134,70 +134,44 @@ defmodule ExplorerSQLTest do
   describe "head/1" do
     test "adds the head operation", %{pid: pid} do
       ldf = ExplorerSQL.table(pid, "links")
-      assert ldf.data.operations == []
-
       ldf = ExplorerSQL.head(ldf)
 
       assert %Explorer.DataFrame{} = ldf
 
-      assert ldf.data.operations == [{:head, [5]}]
+      assert ldf.data.query.limit == "5"
     end
 
     test "adds the head operation with a custom number of rows", %{pid: pid} do
       ldf = ExplorerSQL.table(pid, "links")
-      assert ldf.data.operations == []
-
       ldf = ExplorerSQL.head(ldf, 12)
 
       assert %Explorer.DataFrame{} = ldf
 
-      assert ldf.data.operations == [{:head, [12]}]
-    end
-
-    test "does not add the head operation if it's already there", %{pid: pid} do
-      ldf = ExplorerSQL.table(pid, "links")
-      ldf = ExplorerSQL.head(ldf)
-
-      assert ldf.data.operations == [{:head, [5]}]
-
-      ldf = ExplorerSQL.head(ldf)
-
-      assert ldf.data.operations == [{:head, [5]}]
+      assert ldf.data.query.limit == "12"
     end
   end
 
   describe "select/3" do
-    test "adds a select operation with only two columns", %{pid: pid} do
+    test "adds a select to query with given columns", %{pid: pid} do
       ldf = ExplorerSQL.table(pid, "links")
       ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
 
-      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+      assert ldf.data.query.columns == ["url", "clicks"]
 
       ldf = ExplorerSQL.select(ldf, ["url"], :keep)
 
-      assert ldf.data.operations == [{:select, [["url"]]}, {:select, [["url", "clicks"]]}]
+      assert ldf.data.query.columns == ["url"]
     end
 
     test "adds a select operation removing one column", %{pid: pid} do
       ldf = ExplorerSQL.table(pid, "links")
       ldf = ExplorerSQL.select(ldf, ["id"], :drop)
 
-      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+      assert ldf.data.query.columns == ["url", "clicks"]
 
       ldf = ExplorerSQL.select(ldf, ["clicks"], :drop)
 
-      assert ldf.data.operations == [{:select, [["id", "url"]]}, {:select, [["url", "clicks"]]}]
-    end
-
-    test "does not add the same select operation twice in a row", %{pid: pid} do
-      ldf = ExplorerSQL.table(pid, "links")
-      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
-
-      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
-
-      ldf = ExplorerSQL.select(ldf, ["url", "clicks"], :keep)
-
-      assert ldf.data.operations == [{:select, [["url", "clicks"]]}]
+      assert ldf.data.query.columns == ["id", "url"]
     end
   end
 end


### PR DESCRIPTION
This operation performs the "select" verb by selecting or dropping
columns from our SQL query.

It is going to select columns from a subquery if a limit was already
defined.